### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ArneKr @FrodePedersen @MathiasHaudgaard @bgruening @cbrueffer @conda-forge/r @daler @dbast @jdblischak @johanneskoester
+* @ArneKr @FrodePedersen @MathiasHaudgaard @conda-forge/r

--- a/README.md
+++ b/README.md
@@ -118,11 +118,5 @@ Feedstock Maintainers
 * [@ArneKr](https://github.com/ArneKr/)
 * [@FrodePedersen](https://github.com/FrodePedersen/)
 * [@MathiasHaudgaard](https://github.com/MathiasHaudgaard/)
-* [@bgruening](https://github.com/bgruening/)
-* [@cbrueffer](https://github.com/cbrueffer/)
 * [@conda-forge/r](https://github.com/conda-forge/r/)
-* [@daler](https://github.com/daler/)
-* [@dbast](https://github.com/dbast/)
-* [@jdblischak](https://github.com/jdblischak/)
-* [@johanneskoester](https://github.com/johanneskoester/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,9 +58,3 @@ extra:
     - MathiasHaudgaard
     - FrodePedersen
     - ArneKr
-    - johanneskoester
-    - bgruening
-    - daler
-    - jdblischak
-    - cbrueffer
-    - dbast


### PR DESCRIPTION

Remove individually listed maintainers that are members of the conda-forge/r team

Followed a similar strategy from the docs for updating the maintainers. Unfortunately it doesn't appear possible to skip the CI jobs in the PR itself, even the example PR had jobs run

https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list
